### PR TITLE
Fix menu bar position and behaviour

### DIFF
--- a/meecast/qt-qml/qml/main.qml
+++ b/meecast/qt-qml/qml/main.qml
@@ -35,7 +35,7 @@ PageStackWindow {
 
     Menu {
         id: myMenu
-        visualParent: pageStack
+        // visualParent: pageStack
         MenuLayout {
             MenuItem {
                 id: item1


### PR DESCRIPTION
By parenting the Menu myMenu to the pageStack, the menu appears above the toolbar.
This is inconsistent with other applications on the Nokia N9.

Furthermore, the menu remains open as tabs are switched - the correct behaviour is such that the menu covers the tabs to prevent page switching - otherwise the menu must be closed when switching commands by myMenu.close();.
