### PR TITLE
[build.yml] Build with SDK for SFOS 4.5.0.16, …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 env:
   # For available docker images, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
-  OS_VERSION: 4.3.0.12
+  OS_VERSION: 4.6.0.13
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 env:
   # For available docker images, see https://github.com/CODeRUS/docker-sailfishos-platform-sdk
-  OS_VERSION: 4.6.0.13
+  OS_VERSION: 4.5.0.16
 
 jobs:
   build:


### PR DESCRIPTION
… because RPM packages built for 4.3.0 do run fine on SFOS 4.4.0, 4.5.0 and 4.6.0, but seem to fail on SFOS 5.0.0 as indicated by reports on FSO.
Unfortunately, I do not know which the minimal target release is for executing binaries on SFOS 5.0.0, hence using 4.5.0 which was indicated to work for Storeman at FSO (but these binaries only run on SFOS 4.5.0, 4.6.0 and 5.0.0).