### PR TITLE
[build.yml] Update to latest actions releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
            sudo cp -r RPMS/*.rpm /share/output/' sh_mb2 $OS_VERSION ${{ matrix.arch }}
       
     - name: Upload RPM (${{ matrix.arch }})
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rpm-${{ matrix.arch }}
         path: output
@@ -43,29 +43,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download armv7hl
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rpm-armv7hl
         continue-on-error: true
       - name: Download aarch64
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rpm-aarch64
         continue-on-error: true
       - name: Download i486
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rpm-i486
         continue-on-error: true
       - name: Extract Version Name
         id: extract_name
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           result-encoding: string
           script: |
             return context.payload.ref.replace(/refs\/tags\//, '');
       - name: Create a Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
For the options used here, these newer releases of the GitHub-"actions" which are utilised in the `build.yml` file should be fully compatible:
- https://github.com/actions/download-artifact#readme
- https://github.com/actions/upload-artifact#readme
- https://github.com/actions/github-script#readme
- https://github.com/softprops/action-gh-release#readme

*Edit:* Missed https://github.com/actions/checkout#readme in [line 20](https://github.com/Meecast/meecast/blob/master/.github/workflows/build.yml#L20).  Rectified by [commit `7d22f3d`](https://github.com/Meecast/meecast/commit/7d22f3da765679306244b4384002fb1b20fb291e).